### PR TITLE
Fix broken build due GlyphOrderAndAliasDB_TT moved from root of project

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -13,14 +13,14 @@ mkdir target/TTF/
 for w in ${romanWeights[@]};
 do
   makeotf -f Roman/$w/font.pfa -r -o target/OTF/$family-$w.otf
-  makeotf -f Roman/$w/font.ttf -gf GlyphOrderAndAliasDB_TT -r -o target/TTF/$family-$w.ttf
+  makeotf -f Roman/$w/font.ttf -gf Roman/GlyphOrderAndAliasDB_TT -r -o target/TTF/$family-$w.ttf
   rm Roman/$w/current.fpr # remove default options file from the source tree after building
 done
 
 for w in ${italicWeights[@]};
 do
   makeotf -f Italic/$w/font.pfa -r -o target/OTF/$family-$w.otf
-  makeotf -f Italic/$w/font.ttf -gf GlyphOrderAndAliasDB_TT -r -o target/TTF/$family-$w.ttf
+  makeotf -f Italic/$w/font.ttf -gf Italic/GlyphOrderAndAliasDB_TT -r -o target/TTF/$family-$w.ttf
   rm Italic/$w/current.fpr # remove default options file from the source tree after building
 done
 


### PR DESCRIPTION
Single GlyphOrderAndAliasDB_TT no longer exists in root of project, point build script to versions for Roman and Italic.
