### PR TITLE
Use `make` for more complete and automated build process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,63 @@
+# Makefile for Source Sans Pro font project directory
+
+family=SourceSansPro
+romanWeights=Black Bold ExtraLight Light Regular Semibold
+italicWeights=BlackIt BoldIt ExtraLightIt LightIt It SemiboldIt
+
+OTF_DIR=target/OTF
+TTF_DIR=target/TTF
+
+OTFs:=$(foreach w,$(romanWeights) $(italicWeights),$(OTF_DIR)/$(family)-$w.otf)
+TTFs:=$(subst OTF,TTF,$(OTFs:.otf=.ttf))
+
+instancesRoman:=$(foreach w,$(romanWeights),Roman/$w/font.ufo)
+instancesItalic:=$(foreach w,$(italicWeights),Italic/$w/font.ufo)
+
+all: $(OTFs) $(TTFs)
+
+# Rule below derives the prerequisites of appropriate style from the given
+# target's weight. Paths of targets themselves, though, are more tricky, thus
+# there are two separate rules for the two target formats:
+
+.SECONDEXPANSION:
+$(OTFs): $(OTF_DIR)/$(family)-%.otf: \
+	$(addprefix $$(if $$(findstring It,%),Italic,Roman)/,\
+		%/font.ufo %/fontinfo \
+		%/features %/markclasses.fea %/mark.fea %/mkmk.fea %/kern.fea \
+		GlyphOrderAndAliasDB family.fea) \
+	FontMenuNameDB tables.fea | $(OTF_DIR)
+	makeotf -ga -f $< -o $@
+
+.SECONDEXPANSION:
+$(TTFs): $(TTF_DIR)/$(family)-%.ttf: \
+	$(addprefix $$(if $$(findstring It,%),Italic,Roman)/,\
+		%/font.ttf %/fontinfo \
+		%/features %/markclasses.fea %/mark.fea %/mkmk.fea %/kern.fea \
+		GlyphOrderAndAliasDB family.fea) \
+	FontMenuNameDB tables.fea | $(TTF_DIR)
+	makeotf -ga -f $< -o $@
+
+$(OTF_DIR) $(TTF_DIR):
+	mkdir -p $@
+
+instances: $(instancesRoman) $(instancesItalic)
+
+.SECONDEXPANSION:
+$(instancesRoman) $(instancesItalic): %/font.ufo: \
+	$$(addprefix $$(subst /,,$$(dir %))Masters/,\
+		$(addprefix $(family)$$(if $$(findstring Italic,%),-Italic),\
+			.designspace _0.ufo _1.ufo))
+	makeInstancesUFO -d $<
+
+clean:
+	@rm -f $(addsuffix /current.fpr,\
+		$(addprefix Roman/,$(romanWeights)) \
+		$(addprefix Italic/,$(italicWeights)))
+	@rm -f $(addsuffix /MutatorMath.log,RomanMasters ItalicMasters)
+
+cleanall: clean
+	@rm -rf $(OTF_DIR) $(TTF_DIR)
+
+cleaninstances:
+	@rm -rf $(instancesRoman) $(instancesItalic)
+

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 # Makefile for Source Sans Pro font project directory
+# See README for an overview of make commands
 
 family=SourceSansPro
 romanWeights=Black Bold ExtraLight Light Regular Semibold

--- a/README.md
+++ b/README.md
@@ -57,6 +57,51 @@ or this on Windows:
 > build.cmd
 ```
 
+### Building with `make`
+
+If you want to build directly from masters instead of the instances stored in
+the repository, or to avoid building all files repetitively, run:
+
+```sh
+$ make
+```
+
+and it will get everything up to date. To generate only the font.ufo instances
+from the masters, run:
+
+```sh
+$ make instances
+```
+
+_Note: because font.ufo instances are stored in the repository, you may have to
+delete them first from your working tree before building from masters; see
+below._
+
+To clean up `makeotf`'s defaults and other log files, run:
+
+```sh
+$ make clean
+```
+
+or to remove all build artefacts, including target font binaries:
+
+```sh
+$ make cleanall
+```
+
+Because font.ufo instances are committed into the repository, they are not
+removed on `make clean`. If that is necessary, run:
+
+```sh
+$ make cleaninstances
+```
+
+Note also that font.ttf instances stored in the repository are not generated
+entirely automatically. These TrueType versions of the instances are produced in
+a process that depends on manual workflow [described in detail by Frank
+Grießhammer][1]. Because of that, `make` will build the target TTFs only if it
+finds those files already in place.
+
 ## Getting Involved
 
 Send suggestions for changes to the Source Sans OpenType font project maintainer, [Paul D. Hunt](mailto:opensourcefonts@adobe.com?subject=[GitHub] Source Sans Pro), for consideration.
@@ -64,3 +109,6 @@ Send suggestions for changes to the Source Sans OpenType font project maintainer
 ## Further information
 
 For information about the design and background of Source Sans, please refer to the [official font readme file](http://www.adobe.com/products/type/font-information/source-sans-pro-readme.html).
+
+[1]: <https://github.com/adobe-type-tools/fontlab-scripts/tree/master/TrueType>
+


### PR DESCRIPTION
Makes use of `make` in building the instances as well as all target binaries as discussed in #77. See the Makefile commit message or updates to README for a quick overview of available `make` commands.

It uses the same targets as the current `build.sh` script, so they can be used side by side. Instances are not cleaned up by default, so they can be committed into the repository as usual. I’ve also added a note on how TrueType versions of the instances are produced to address questions like #78; feel free to amend it as necessary.

The whole directory setup is rather non-standard in terms of `make` pattern syntax, so the rules may seem a bit involved at first. The overall formatting, though, makes it pretty clear what depends on what, so it shouldn't be a problem to modify or extend it in the future.

Tested on OS X with a fresh clone of the repository and the latest stable release of AFDKO. Note that the current master of the FDK still throws errors on post-processing the generated instances as reported in #77.