### PR TITLE
Add missing anchors

### DIFF
--- a/Roman/Instances/Black/font.ufo/glyphs/R_smallinverted.glif
+++ b/Roman/Instances/Black/font.ufo/glyphs/R_smallinverted.glif
@@ -33,5 +33,11 @@
 			<point x="199" y="500" type="line"/>
 			<point x="8" y="500" type="line"/>
 		</contour>
+		<contour>
+			<point name="aboveUC" x="248" y="502" type="move"/>
+		</contour>
+		<contour>
+			<point name="belowLC" x="270" y="-22" type="move"/>
+		</contour>
 	</outline>
 </glyph>

--- a/Roman/Instances/Black/font.ufo/glyphs/rfishhook.glif
+++ b/Roman/Instances/Black/font.ufo/glyphs/rfishhook.glif
@@ -21,5 +21,8 @@
 			<point x="58" y="412"/>
 			<point x="58" y="300" type="curve" smooth="yes"/>
 		</contour>
+		<contour>
+			<point name="aboveLC" x="258" y="522" type="move"/>
+		</contour>
 	</outline>
 </glyph>

--- a/Roman/Instances/Bold/font.ufo/glyphs/R_smallinverted.glif
+++ b/Roman/Instances/Bold/font.ufo/glyphs/R_smallinverted.glif
@@ -33,5 +33,11 @@
 			<point x="178" y="496" type="line"/>
 			<point x="15" y="496" type="line"/>
 		</contour>
+		<contour>
+			<point name="aboveUC" x="248" y="502" type="move"/>
+		</contour>
+		<contour>
+			<point name="belowLC" x="270" y="-22" type="move"/>
+		</contour>
 	</outline>
 </glyph>

--- a/Roman/Instances/Bold/font.ufo/glyphs/rfishhook.glif
+++ b/Roman/Instances/Bold/font.ufo/glyphs/rfishhook.glif
@@ -21,5 +21,8 @@
 			<point x="65" y="416"/>
 			<point x="65" y="304" type="curve" smooth="yes"/>
 		</contour>
+		<contour>
+			<point name="aboveLC" x="246" y="518" type="move"/>
+		</contour>
 	</outline>
 </glyph>

--- a/Roman/Instances/Light/font.ufo/glyphs/R_smallinverted.glif
+++ b/Roman/Instances/Light/font.ufo/glyphs/R_smallinverted.glif
@@ -33,5 +33,11 @@
 			<point x="92" y="480" type="line"/>
 			<point x="42" y="480" type="line"/>
 		</contour>
+		<contour>
+			<point name="aboveUC" x="248" y="502" type="move"/>
+		</contour>
+		<contour>
+			<point name="belowLC" x="270" y="-22" type="move"/>
+		</contour>
 	</outline>
 </glyph>

--- a/Roman/Instances/Light/font.ufo/glyphs/rfishhook.glif
+++ b/Roman/Instances/Light/font.ufo/glyphs/rfishhook.glif
@@ -21,5 +21,8 @@
 			<point x="92" y="435"/>
 			<point x="92" y="320" type="curve" smooth="yes"/>
 		</contour>
+		<contour>
+			<point name="aboveLC" x="199" y="504" type="move"/>
+		</contour>
 	</outline>
 </glyph>

--- a/Roman/Instances/Regular/font.ufo/glyphs/R_smallinverted.glif
+++ b/Roman/Instances/Regular/font.ufo/glyphs/R_smallinverted.glif
@@ -33,5 +33,11 @@
 			<point x="124" y="486" type="line"/>
 			<point x="32" y="486" type="line"/>
 		</contour>
+		<contour>
+			<point name="aboveUC" x="248" y="502" type="move"/>
+		</contour>
+		<contour>
+			<point name="belowLC" x="270" y="-22" type="move"/>
+		</contour>
 	</outline>
 </glyph>

--- a/Roman/Instances/Regular/font.ufo/glyphs/rfishhook.glif
+++ b/Roman/Instances/Regular/font.ufo/glyphs/rfishhook.glif
@@ -21,5 +21,8 @@
 			<point x="82" y="428"/>
 			<point x="82" y="314" type="curve" smooth="yes"/>
 		</contour>
+		<contour>
+			<point name="aboveLC" x="216" y="509" type="move"/>
+		</contour>
 	</outline>
 </glyph>

--- a/Roman/Instances/Semibold/font.ufo/glyphs/R_smallinverted.glif
+++ b/Roman/Instances/Semibold/font.ufo/glyphs/R_smallinverted.glif
@@ -33,5 +33,11 @@
 			<point x="151" y="491" type="line"/>
 			<point x="23" y="491" type="line"/>
 		</contour>
+		<contour>
+			<point name="aboveUC" x="248" y="502" type="move"/>
+		</contour>
+		<contour>
+			<point name="belowLC" x="270" y="-22" type="move"/>
+		</contour>
 	</outline>
 </glyph>

--- a/Roman/Instances/Semibold/font.ufo/glyphs/rfishhook.glif
+++ b/Roman/Instances/Semibold/font.ufo/glyphs/rfishhook.glif
@@ -21,5 +21,8 @@
 			<point x="73" y="422"/>
 			<point x="73" y="309" type="curve" smooth="yes"/>
 		</contour>
+		<contour>
+			<point name="aboveLC" x="232" y="514" type="move"/>
+		</contour>
 	</outline>
 </glyph>

--- a/Roman/Masters/master_1/SourceSans_Black.ufo/glyphs/R_smallinverted.glif
+++ b/Roman/Masters/master_1/SourceSans_Black.ufo/glyphs/R_smallinverted.glif
@@ -33,5 +33,11 @@
 			<point x="199" y="500" type="line"/>
 			<point x="8" y="500" type="line"/>
 		</contour>
+		<contour>
+			<point name="belowLC" x="270" y="-22" type="move"/>
+		</contour>
+		<contour>
+			<point name="aboveUC" x="248" y="502" type="move"/>
+		</contour>
 	</outline>
 </glyph>

--- a/Roman/Masters/master_1/SourceSans_Black.ufo/glyphs/rfishhook.glif
+++ b/Roman/Masters/master_1/SourceSans_Black.ufo/glyphs/rfishhook.glif
@@ -21,5 +21,8 @@
 			<point x="58" y="412"/>
 			<point x="58" y="300" type="curve" smooth="yes"/>
 		</contour>
+		<contour>
+			<point name="aboveLC" x="258" y="522" type="move"/>
+		</contour>
 	</outline>
 </glyph>


### PR DESCRIPTION
No idea if these anchors are used at all, but the some masters have them and the others don’t, which breaks building a variable font with fontmake (at least for me). Alternatively the anchors can be dropped from the masters that have them if they aren’t actually needed.
  