### PR TITLE
Rework the Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ Source*.ttf
 */*/*/master.ufo/glyphs.com.adobe.type.processedGlyphs
 */*/*/master.ufo/data/com.adobe.type.processedHashMap
 */*/*/master.ufo/layercontents.plist
+*~

--- a/Makefile
+++ b/Makefile
@@ -1,64 +1,19 @@
-# Makefile for Source Sans Pro font project directory
-# See README for an overview of make commands
+#!/usr/bin/make
+# -*- indent-tabs-mode: t; -*-
+# by Al Nikolov <root@toor.fi.eu.org>
 
-family=SourceSansPro
-romanWeights=Black Bold ExtraLight Light Regular Semibold
-italicWeights=BlackIt BoldIt ExtraLightIt LightIt It SemiboldIt
+dnames = $(wildcard $(addsuffix /Instances/*,Roman Italic))
+fnames = $(addsuffix .otf,$(addprefix /SourceSansPro-,$(notdir $(dnames))))
+wholenames = $(join $(dnames),$(fnames))
+out_pat = -name \*.[ot]tf
 
-OTF_DIR=target/OTF
-TTF_DIR=target/TTF
-
-OTFs:=$(foreach w,$(romanWeights) $(italicWeights),$(OTF_DIR)/$(family)-$w.otf)
-TTFs:=$(subst OTF,TTF,$(OTFs:.otf=.ttf))
-
-instancesRoman:=$(foreach w,$(romanWeights),Roman/$w/font.ufo)
-instancesItalic:=$(foreach w,$(italicWeights),Italic/$w/font.ufo)
-
-all: $(OTFs) $(TTFs)
-
-# Rule below derives the prerequisites of appropriate style from the given
-# target's weight. Paths of targets themselves, though, are more tricky, thus
-# there are two separate rules for the two target formats:
-
-.SECONDEXPANSION:
-$(OTFs): $(OTF_DIR)/$(family)-%.otf: \
-	$(addprefix $$(if $$(findstring It,%),Italic,Roman)/,\
-		%/font.ufo %/fontinfo \
-		%/features %/markclasses.fea %/mark.fea %/mkmk.fea %/kern.fea \
-		GlyphOrderAndAliasDB family.fea) \
-	FontMenuNameDB tables.fea | $(OTF_DIR)
-	makeotf -ga -f $< -o $@
-
-.SECONDEXPANSION:
-$(TTFs): $(TTF_DIR)/$(family)-%.ttf: \
-	$(addprefix $$(if $$(findstring It,%),Italic,Roman)/,\
-		%/font.ttf %/fontinfo \
-		%/features %/markclasses.fea %/mark.fea %/mkmk.fea %/kern.fea \
-		GlyphOrderAndAliasDB family.fea) \
-	FontMenuNameDB tables.fea | $(TTF_DIR)
-	makeotf -ga -f $< -o $@
-
-$(OTF_DIR) $(TTF_DIR):
-	mkdir -p $@
-
-instances: $(instancesRoman) $(instancesItalic)
-
-.SECONDEXPANSION:
-$(instancesRoman) $(instancesItalic): %/font.ufo: \
-	$$(addprefix $$(subst /,,$$(dir %))Masters/,\
-		$(addprefix $(family)$$(if $$(findstring Italic,%),-Italic),\
-			.designspace _0.ufo _1.ufo))
-	makeInstancesUFO -d $<
+all: $(wholenames)
 
 clean:
-	@rm -f $(addsuffix /current.fpr,\
-		$(addprefix Roman/,$(romanWeights)) \
-		$(addprefix Italic/,$(italicWeights)))
-	@rm -f $(addsuffix /MutatorMath.log,RomanMasters ItalicMasters)
+	find $(out_pat) | xargs ${RM}
 
-cleanall: clean
-	@rm -rf $(OTF_DIR) $(TTF_DIR)
+.PHONY: all clean
 
-cleaninstances:
-	@rm -rf $(instancesRoman) $(instancesItalic)
-
+.SECONDEXPANSION:
+%.otf: $$(shell find $$(@D) ! $(out_pat))
+	cd $(@D) && makeotf -r -gs -omitMacNames


### PR DESCRIPTION
Here's some tests with timing:

```
$ make clean; time make Roman/Instances/Regular/SourceSansPro-Regular.otf
find -name \*.[ot]tf | xargs rm -f
...
real	0m4.640s
user	0m3.680s
sys	0m0.566s


$ time make Roman/Instances/Regular/SourceSansPro-Regular.otf
make: «Roman/Instances/Regular/SourceSansPro-Regular.otf» is up to date.

real	0m1.929s
user	0m1.610s
sys	0m0.167s


$ make clean; time make
find -name \*.[ot]tf | xargs rm -f
...
real	0m53.129s
user	0m41.615s
sys	0m6.831s


$ time make
make: Nothing to be done for 'all'.

real	0m21.558s
user	0m18.327s
sys	0m1.431s
```