### PR TITLE
Correct `format()` in `source-sans-3VF.css`

### DIFF
--- a/source-sans-3VF.css
+++ b/source-sans-3VF.css
@@ -3,9 +3,9 @@
     font-weight: 200 900;
     font-style: normal;
     font-stretch: normal;
-    src: url('WOFF2/VF/SourceSans3VF-Upright.ttf.woff2') format('woff2'),
-         url('WOFF/VF/SourceSans3VF-Upright.ttf.woff') format('woff'),
-         url('VF/SourceSans3VF-Upright.ttf') format('truetype');
+    src: url('WOFF2/VF/SourceSans3VF-Upright.ttf.woff2') format('woff2-variations'),
+         url('WOFF/VF/SourceSans3VF-Upright.ttf.woff') format('woff-variations'),
+         url('VF/SourceSans3VF-Upright.ttf') format('truetype-variations');
 }
 
 @font-face{
@@ -13,7 +13,7 @@
     font-weight: 200 900;
     font-style: italic;
     font-stretch: normal;
-    src: url('WOFF2/VF/SourceSans3VF-Italic.ttf.woff2') format('woff2'),
-         url('WOFF/VF/SourceSans3VF-Italic.ttf.woff') format('woff'),
-         url('VF/SourceSans3VF-Italic.ttf') format('truetype');
+    src: url('WOFF2/VF/SourceSans3VF-Italic.ttf.woff2') format('woff2-variations'),
+         url('WOFF/VF/SourceSans3VF-Italic.ttf.woff') format('woff-variations'),
+         url('VF/SourceSans3VF-Italic.ttf') format('truetype-variations');
 }


### PR DESCRIPTION
This is required to let browsers that don’t support variable fonts (e.g. Firefox on Windows 8) avoid downloading them and fall back to something usable.

Same fix in source-serif and source-code-pro:

- adobe-fonts/source-serif#129
- adobe-fonts/source-code-pro#320